### PR TITLE
Replace directory separator in mailbox name

### DIFF
--- a/mbox_split.py
+++ b/mbox_split.py
@@ -1,11 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Adapted from:
 # http://wboptimum.com/splitting-gmail-mbox-by-label/
 
-import sys
 import getopt
 import mailbox
+import os
+import sys
 
 def main(argv):
 	in_mbox = "inbox.mbox"
@@ -40,7 +41,7 @@ def main(argv):
 			saved = False
 			for label in gmail_labels.split(','):
 				if label != "important" and label != "unread" and label != "starred" and label != "newsletters":
-					box_name = prefix+label.title()+".mbox"
+					box_name = prefix + label.title().replace(os.pathsep, '.') + ".mbox"
 					if box_name not in boxes:
 						boxes[box_name] = mailbox.mbox(box_name, None, True)
 					boxes[box_name].add(message)


### PR DESCRIPTION
Hey Dan,

I stumbled upon your repo and found your script quite useful, though it needed a few tweaks to make it work with my needs.

Some of my Gmail folders contain a `/` character, which crashes mbox_split.py as it tries to create a file in a subdirectory which doesn't exist. I think there are two options here:

1. Replace the slash with a period, which is how the Maildir format handles nested folders (proposed in this PR);
2. Actually create the subdirectory, including nested folders as needed.

I say "slash" above but I'm targeting whatever separator the OS uses.

Also included in this PR is a modification to the shebang. As you might now Python 2 has now reached "end-of-life" status. It is no longer included in Debian for example, which I use on my mail server. 